### PR TITLE
Improved test coveregae

### DIFF
--- a/auth_saml/tests/__init__.py
+++ b/auth_saml/tests/__init__.py
@@ -1,1 +1,1 @@
-from . import fake_idp, test_pysaml
+from . import fake_idp, test_pysaml, test_models_saml_attribute_mapping

--- a/auth_saml/tests/fake_idp.py
+++ b/auth_saml/tests/fake_idp.py
@@ -79,6 +79,7 @@ class DummyResponse:
         self.text = data
         self.headers = headers or []
         self.content = data
+        self._identity = {}
 
     def _unpack(self, ver="SAMLResponse"):
         """
@@ -102,6 +103,18 @@ class DummyResponse:
         rs = _str[start:end]
 
         return {ver: sr, "RelayState": rs}
+
+    def get_identity(self):
+        """
+        Return the identity attributes
+        """
+        return self._identity
+    
+    def set_identity(self, identity):
+        """
+        Set the identity attributes
+        """
+        self._identity = identity        
 
 
 class FakeIDP(Server):

--- a/auth_saml/tests/test_models_saml_attribute_mapping.py
+++ b/auth_saml/tests/test_models_saml_attribute_mapping.py
@@ -1,0 +1,24 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestAuthSamlModelsSamlAttributeMapping(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+        self.SamlAttributeMapping = self.env['auth.saml.attribute.mapping']
+
+    def test_field_name_selection(self):
+        # Call the method
+        field_name_selection = self.SamlAttributeMapping._field_name_selection()
+
+        # Fetch all user fields
+        user_fields = self.env['res.users'].fields_get().items()
+
+        # Filter out valid fields (char and not readonly)
+        valid_fields = [(f, d.get('string')) for f, d in user_fields if d.get('type') == 'char' and not d.get('readonly')]
+
+        # Sort the valid fields by their name
+        valid_fields.sort(key=lambda r: r[1])
+
+        # Assert that the selections match the valid fields
+        self.assertEqual(field_name_selection, valid_fields)

--- a/auth_saml/tests/test_pysaml.py
+++ b/auth_saml/tests/test_pysaml.py
@@ -2,12 +2,13 @@
 import base64
 import html
 import os
+import urllib
 from unittest.mock import patch
 
 from odoo.exceptions import AccessDenied, UserError, ValidationError
 from odoo.tests import HttpCase, tagged
 
-from .fake_idp import FakeIDP
+from .fake_idp import FakeIDP, DummyResponse
 
 
 @tagged("saml", "post_install", "-at_install")
@@ -97,6 +98,70 @@ class TestPySaml(HttpCase):
             ),
             response.text,
         )
+
+    def test__onchange_name(self):
+        temp = self.saml_provider.body
+        self.saml_provider.body = ""
+        r = self.saml_provider._onchange_name()
+        self.assertEqual(r, None)
+        self.assertEqual(self.saml_provider.body, self.saml_provider.name)
+        self.saml_provider.body = temp
+
+    def test__compute_sp_metadata_url__new_provider(self):
+         # Create a new unsaved record
+        new_provider = self.env["auth.saml.provider"].new({
+            'name': 'New SAML Provider',
+            'sp_baseurl': 'http://example.com'
+        })
+        # Compute the metadata URL
+        new_provider._compute_sp_metadata_url()
+        # Assert that sp_metadata_url is False for the new record
+        self.assertFalse(new_provider.sp_metadata_url)
+        new_provider.unlink()
+
+    def test__compute_sp_metadata_url__provider_has_sp_baseurl(self):
+        # Create a new saved record with sp_baseurl set
+        temp = self.saml_provider.sp_baseurl
+        self.saml_provider.sp_baseurl = 'http://example.com'
+        self.saml_provider._compute_sp_metadata_url()
+        expected_qs = urllib.parse.urlencode({"p": self.saml_provider.id, "d": self.env.cr.dbname})
+        expected_url = urllib.parse.urljoin('http://example.com', ("/auth_saml/metadata?%s" % expected_qs))
+        # Assert that sp_metadata_url is set correctly
+        self.assertEqual(self.saml_provider.sp_metadata_url, expected_url)
+        self.saml_provider.sp_baseurl = temp
+
+    def test__hook_validate_auth_response(self):
+        # Create a fake response with attributes
+        fake_response = DummyResponse(200, 'fake_data')
+        fake_response.set_identity({
+            "email": "new_user@example.com",
+            "first_name": "New",
+            "last_name": "User"
+        })
+
+        # Add attribute mappings to the provider
+        self.saml_provider.attribute_mapping_ids = [
+            (0, 0, {"attribute_name": "email", "field_name": "login"}),
+            (0, 0, {"attribute_name": "first_name", "field_name": "name"}),
+            (0, 0, {"attribute_name": "nick_name", "field_name": "name"}),  # This attribute is not in attrs
+        ]
+
+        # Call the method
+        result = self.saml_provider._hook_validate_auth_response(fake_response, "test@example.com")
+
+        # Check the result
+        self.assertIn("mapped_attrs", result)
+        self.assertEqual(result["mapped_attrs"]["login"], "new_user@example.com")
+        self.assertEqual(result["mapped_attrs"]["name"], "New")
+        self.assertNotIn("middle_name", result["mapped_attrs"])        
+
+
+    def test__get_config_for_provider(self):
+        temp = self.saml_provider.sp_baseurl
+        self.saml_provider.sp_baseurl = 'http://example.com'
+        config = self.saml_provider._get_config_for_provider(None)
+        self.saml_provider.sp_baseurl = temp
+
 
     def test_ensure_metadata_present(self):
         response = self.url_open(


### PR DESCRIPTION
Hello @astirpe, 

I added some tests to class PyTestSaml. I had to expand class DummyResponse to include set_identity() and get_identity(). 

Here is the current coverage of this package:

```
Name                                                                                Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------------------------------------------------
/root/workspace/server-auth/auth_saml/__init__.py                                       1      0   100%
/root/workspace/server-auth/auth_saml/__manifest__.py                                   1      1     0%   5
/root/workspace/server-auth/auth_saml/controllers/__init__.py                           1      0   100%
/root/workspace/server-auth/auth_saml/controllers/main.py                             152     36    76%   42, 89, 109-111, 123, 128, 136, 138, 140, 150, 185, 209-212, 218, 240-243, 249-266, 275-276, 286
/root/workspace/server-auth/auth_saml/models/__init__.py                                1      0   100%
/root/workspace/server-auth/auth_saml/models/auth_saml_attribute_mapping.py            15      0   100%
/root/workspace/server-auth/auth_saml/models/auth_saml_provider.py                    151      8    95%   185-188, 293, 303, 312, 368
/root/workspace/server-auth/auth_saml/models/auth_saml_request.py                       7      0   100%
/root/workspace/server-auth/auth_saml/models/ir_config_parameter.py                    23      4    83%   19-22
/root/workspace/server-auth/auth_saml/models/res_config_settings.py                     5      0   100%
/root/workspace/server-auth/auth_saml/models/res_users.py                              72      3    96%   58, 68, 74
/root/workspace/server-auth/auth_saml/models/res_users_saml.py                         15      0   100%
/root/workspace/server-auth/auth_saml/tests/__init__.py                                 1      0   100%
/root/workspace/server-auth/auth_saml/tests/fake_idp.py                                64      1    98%   156
/root/workspace/server-auth/auth_saml/tests/test_models_saml_attribute_mapping.py      11      0   100%
/root/workspace/server-auth/auth_saml/tests/test_pysaml.py                            148      0   100%
-----------------------------------------------------------------------------------------------------------------
TOTAL                                                                                 668     53    92%
```

I hope this is enough.